### PR TITLE
fix bug in resolving templates if strings contain escaped quotes

### DIFF
--- a/source/endpoints_util.c
+++ b/source/endpoints_util.c
@@ -333,10 +333,18 @@ static bool s_split_on_first_delim(
 static int s_buf_append_and_update_quote_count(
     struct aws_byte_buf *buf,
     struct aws_byte_cursor to_append,
-    size_t *quote_count) {
-    for (size_t idx = 0; idx < to_append.len; ++idx) {
-        if (to_append.ptr[idx] == '"' && !(idx > 0 && to_append.ptr[idx - 1] == '\\')) {
-            ++*quote_count;
+    size_t *quote_count,
+    bool is_json) {
+
+    /* Dont count quotes if its not json. escaped quotes will be replaced with
+    regular quotes when ruleset json is parsed, which will lead to incorrect
+    results for when templates should be resolved in regular strings. 
+    Note: in json blobs escaped quotes are preserved and bellow approach works. */ 
+    if (is_json) {
+        for (size_t idx = 0; idx < to_append.len; ++idx) {
+            if (to_append.ptr[idx] == '"' && !(idx > 0 && to_append.ptr[idx - 1] == '\\')) {
+                ++*quote_count;
+            }
         }
     }
     return aws_byte_buf_append_dynamic(buf, &to_append);
@@ -354,12 +362,14 @@ static struct aws_byte_cursor escaped_opening_curly = AWS_BYTE_CUR_INIT_FROM_STR
 int s_append_template_prefix_to_buffer(
     struct aws_byte_buf *out_buf,
     struct aws_byte_cursor prefix,
-    size_t *quote_count) {
+    size_t *quote_count, 
+    bool is_json) {
+
     struct aws_byte_cursor split = {0};
     struct aws_byte_cursor rest = {0};
 
     while (s_split_on_first_delim(prefix, '}', &split, &rest)) {
-        if (s_buf_append_and_update_quote_count(out_buf, split, quote_count)) {
+        if (s_buf_append_and_update_quote_count(out_buf, split, quote_count, is_json)) {
             AWS_LOGF_ERROR(AWS_LS_SDKUTILS_ENDPOINTS_GENERAL, "Failed to append to resolved template buffer.");
             goto on_error;
         }
@@ -388,7 +398,7 @@ int s_append_template_prefix_to_buffer(
         prefix = rest;
     }
 
-    if (s_buf_append_and_update_quote_count(out_buf, split, quote_count)) {
+    if (s_buf_append_and_update_quote_count(out_buf, split, quote_count, is_json)) {
         AWS_LOGF_ERROR(AWS_LS_SDKUTILS_ENDPOINTS_GENERAL, "Failed to append to resolved template buffer.");
         goto on_error;
     }
@@ -419,7 +429,7 @@ int aws_byte_buf_init_from_resolved_templated_string(
     struct aws_byte_cursor split = {0};
     struct aws_byte_cursor rest = {0};
     while (s_split_on_first_delim(string, '{', &split, &rest)) {
-        if (s_append_template_prefix_to_buffer(out_buf, split, &quote_count)) {
+        if (s_append_template_prefix_to_buffer(out_buf, split, &quote_count, is_json)) {
             AWS_LOGF_ERROR(
                 AWS_LS_SDKUTILS_ENDPOINTS_GENERAL, "Failed to append to buffer while evaluating templated sting.");
             goto on_error;
@@ -460,7 +470,7 @@ int aws_byte_buf_init_from_resolved_templated_string(
             goto on_error;
         }
 
-        if (s_buf_append_and_update_quote_count(out_buf, resolved_template.cur, &quote_count)) {
+        if (s_buf_append_and_update_quote_count(out_buf, resolved_template.cur, &quote_count, is_json)) {
             AWS_LOGF_ERROR(AWS_LS_SDKUTILS_ENDPOINTS_GENERAL, "Failed to append resolved value.");
             goto on_error;
         }
@@ -468,7 +478,7 @@ int aws_byte_buf_init_from_resolved_templated_string(
         aws_owning_cursor_clean_up(&resolved_template);
     }
 
-    if (s_buf_append_and_update_quote_count(out_buf, split, &quote_count)) {
+    if (s_buf_append_and_update_quote_count(out_buf, split, &quote_count, is_json)) {
         AWS_LOGF_ERROR(AWS_LS_SDKUTILS_ENDPOINTS_GENERAL, "Failed to append to resolved template buffer.");
         goto on_error;
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -87,6 +87,7 @@ add_test_case(endpoints_eval_util_is_ipv4)
 add_test_case(endpoints_eval_util_is_ipv6)
 add_test_case(endpoints_map_region_to_partition)
 add_test_case(endpoints_uri_normalize_path)
+add_test_case(endpoints_byte_buf_init_from_resolved_templated_string)
 
 set(TEST_BINARY_NAME ${PROJECT_NAME}-tests)
 generate_test_driver(${TEST_BINARY_NAME})

--- a/tests/endpoints_util_tests.c
+++ b/tests/endpoints_util_tests.c
@@ -136,3 +136,36 @@ static int s_test_uri_normalize_path(struct aws_allocator *allocator, void *ctx)
 
     return AWS_OP_SUCCESS;
 }
+
+int s_resolve_cb(struct aws_byte_cursor template, void *user_data, struct aws_owning_cursor *out_resolved) {
+    *out_resolved = aws_endpoints_non_owning_cursor_create(aws_byte_cursor_from_c_str("test"));
+    return AWS_OP_SUCCESS;
+}
+
+AWS_TEST_CASE(endpoints_byte_buf_init_from_resolved_templated_string, s_test_byte_buf_init_from_resolved_templated_string)
+static int s_test_byte_buf_init_from_resolved_templated_string(struct aws_allocator *allocator, void *ctx) {
+
+    struct aws_byte_buf buf;
+
+    ASSERT_SUCCESS(aws_byte_buf_init_from_resolved_templated_string(allocator, &buf,
+        aws_byte_cursor_from_c_str("{e} a {b}{c} a {d}"), s_resolve_cb, NULL,false));
+    ASSERT_CURSOR_VALUE_CSTRING_EQUALS(aws_byte_cursor_from_buf(&buf), "test a testtest a test");
+    aws_byte_buf_clean_up(&buf);
+
+    ASSERT_SUCCESS(aws_byte_buf_init_from_resolved_templated_string(allocator, &buf,
+        aws_byte_cursor_from_c_str("{ \"a\": \"{b} {d} \", \"c\": \" {e} \"}"), s_resolve_cb, NULL,true));
+    ASSERT_CURSOR_VALUE_CSTRING_EQUALS(aws_byte_cursor_from_buf(&buf), "{ \"a\": \"test test \", \"c\": \" test \"}");
+    aws_byte_buf_clean_up(&buf);
+
+    ASSERT_SUCCESS(aws_byte_buf_init_from_resolved_templated_string(allocator, &buf,
+        aws_byte_cursor_from_c_str("a \" {b} \" a"), s_resolve_cb, NULL,false));
+    ASSERT_CURSOR_VALUE_CSTRING_EQUALS(aws_byte_cursor_from_buf(&buf), "a \" test \" a");
+    aws_byte_buf_clean_up(&buf);
+
+    ASSERT_SUCCESS(aws_byte_buf_init_from_resolved_templated_string(allocator, &buf,
+        aws_byte_cursor_from_c_str("{ \"a\": \"a \\\" {b} \\\" a\" }"), s_resolve_cb, NULL,true));
+    ASSERT_CURSOR_VALUE_CSTRING_EQUALS(aws_byte_cursor_from_buf(&buf), "{ \"a\": \"a \\\" test \\\" a\" }");
+    aws_byte_buf_clean_up(&buf);
+
+    return AWS_OP_SUCCESS;
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Endpoints template resolution supports replacing templates both within regular string and within json blobs. 
To determine when value needs to be replaced within json it relies on counting quotes. For non json blobs this approach does not work because escaped quotes are replaced with regular quotes affecting the count.
Disable counting for non-json blobs, cause it does not matter in that case.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
