### PR TITLE
Fix build warning in ruleset parser

### DIFF
--- a/source/endpoints_ruleset.c
+++ b/source/endpoints_ruleset.c
@@ -342,7 +342,7 @@ static int s_parse_function(
 
     function->fn = AWS_ENDPOINTS_FN_LAST;
     uint64_t hash = aws_hash_byte_cursor_ptr(&fn_cur);
-    for (size_t idx = AWS_ENDPOINTS_FN_FIRST; idx < AWS_ENDPOINTS_FN_LAST; ++idx) {
+    for (int idx = AWS_ENDPOINTS_FN_FIRST; idx < AWS_ENDPOINTS_FN_LAST; ++idx) {
         if (aws_endpoints_fn_name_hash[idx] == hash) {
             function->fn = idx;
             break;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Enums have int types according to the standard. Assigning size_t to enum value will result in a warning on some platforms. 
Switching the loop variable type to be int

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
