### PR TITLE
fix handling of description in partitions file

### DIFF
--- a/source/partitions.c
+++ b/source/partitions.c
@@ -47,16 +47,16 @@ static int s_on_region_merge(
     struct region_merge_wrapper *merge = user_data;
 
     /*
-    * Note: latest partitions file includes description on every region.
-    * This results in a separate record created for every region, since any
-    * overrides on region create a new record that is a merge of partition
-    * default and override.
-    * Description is not used by endpoints rule engine, hence lets ignore it
-    * during merge for now to avoid creating numerous records that all have the
-    * same data.
-    * This decision can be revisited lated if we decide to extend partitions
-    * parsing for any other use cases.
-    */
+     * Note: latest partitions file includes description on every region.
+     * This results in a separate record created for every region, since any
+     * overrides on region create a new record that is a merge of partition
+     * default and override.
+     * Description is not used by endpoints rule engine, hence lets ignore it
+     * during merge for now to avoid creating numerous records that all have the
+     * same data.
+     * This decision can be revisited later if we decide to extend partitions
+     * parsing for any other use cases.
+     */
     if (aws_byte_cursor_eq_c_str(key, "description")) {
         return AWS_OP_SUCCESS;
     }
@@ -66,11 +66,10 @@ static int s_on_region_merge(
     }
 
     /*
-    * Note: Its valid for region to add new field to default partition outputs
-    * instead of overriding existing one. So only delete previous value if it exists.
-    */
-    if (aws_json_value_has_key(merge->merge_node, *key) &&
-        aws_json_value_remove_from_object(merge->merge_node, *key)) {
+     * Note: Its valid for region to add new field to default partition outputs
+     * instead of overriding existing one. So only delete previous value if it exists.
+     */
+    if (aws_json_value_has_key(merge->merge_node, *key) && aws_json_value_remove_from_object(merge->merge_node, *key)) {
         AWS_LOGF_ERROR(AWS_LS_SDKUTILS_PARTITIONS_PARSING, "Failed to remove previous partition value.");
         return aws_raise_error(AWS_ERROR_SDKUTILS_PARTITIONS_PARSE_FAILED);
     }

--- a/tests/resources/sample_partitions.json
+++ b/tests/resources/sample_partitions.json
@@ -28,7 +28,9 @@
           "us-east-1": {},
           "us-east-2": {},
           "us-west-1": {},
-          "us-west-2": {},
+          "us-west-2": {
+            "description" : "US West (Oregon)"
+          },
           "aws-global": {}
         },
         "outputs": {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Partitions file recently introduced a new description field to the region. This breaks partition parsing, since current logic only supports region fields that override the existing default values, but not add to them. 
Fixed region fields to have additive behavior. Also filtering out description field from parsing for endpoints, since it has no use in endpoints rule engine, but results in a lot of additional copies.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
