### PR TITLE
Explicit void parameter for aws_endpoints_rule_engine_init

### DIFF
--- a/source/endpoints_types_impl.c
+++ b/source/endpoints_types_impl.c
@@ -12,7 +12,7 @@
 
 uint64_t aws_endpoints_fn_name_hash[AWS_ENDPOINTS_FN_LAST];
 
-void aws_endpoints_rule_engine_init() {
+void aws_endpoints_rule_engine_init(void) {
     aws_endpoints_fn_name_hash[AWS_ENDPOINTS_FN_IS_SET] = aws_hash_c_string("isSet");
     aws_endpoints_fn_name_hash[AWS_ENDPOINTS_FN_NOT] = aws_hash_c_string("not");
     aws_endpoints_fn_name_hash[AWS_ENDPOINTS_FN_GET_ATTR] = aws_hash_c_string("getAttr");


### PR DESCRIPTION
Usually captured by clang as a warning: 
source/endpoints_types_impl.c:15:36: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes] void aws_endpoints_rule_engine_init() {
                                   ^
                                    void

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
