### PR TITLE
Fix warnings in public headers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,8 @@ on:
       - 'main'
 
 env:
-  BUILDER_VERSION: v0.9.26
-  BUILDER_SOURCE: releases
+  BUILDER_VERSION: header-warnings
+  BUILDER_SOURCE: channels
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-c-sdkutils
   LINUX_BASE_IMAGE: ubuntu-18-x64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,8 @@ on:
       - 'main'
 
 env:
-  BUILDER_VERSION: header-warnings
-  BUILDER_SOURCE: channels
+  BUILDER_VERSION: v0.9.43
+  BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-c-sdkutils
   LINUX_BASE_IMAGE: ubuntu-18-x64

--- a/include/aws/sdkutils/aws_profile.h
+++ b/include/aws/sdkutils/aws_profile.h
@@ -7,6 +7,8 @@
 #define AWS_SDKUTILS_AWS_PROFILE_H
 #include <aws/sdkutils/sdkutils.h>
 
+AWS_PUSH_SANE_WARNING_LEVEL
+
 struct aws_allocator;
 struct aws_string;
 struct aws_byte_buf;
@@ -214,5 +216,6 @@ AWS_SDKUTILS_API
 struct aws_string *aws_get_profile_name(struct aws_allocator *allocator, const struct aws_byte_cursor *override_name);
 
 AWS_EXTERN_C_END
+AWS_POP_SANE_WARNING_LEVEL
 
 #endif /* AWS_SDKUTILS_AWS_PROFILE_H */

--- a/include/aws/sdkutils/endpoints_rule_engine.h
+++ b/include/aws/sdkutils/endpoints_rule_engine.h
@@ -9,6 +9,8 @@
 #include <aws/common/byte_buf.h>
 #include <aws/sdkutils/sdkutils.h>
 
+AWS_PUSH_SANE_WARNING_LEVEL
+
 struct aws_endpoints_ruleset;
 struct aws_partitions_config;
 struct aws_endpoints_parameter;
@@ -299,5 +301,6 @@ AWS_SDKUTILS_API int aws_endpoints_resolved_endpoint_get_error(
     struct aws_byte_cursor *out_error);
 
 AWS_EXTERN_C_END
+AWS_POP_SANE_WARNING_LEVEL
 
 #endif /* AWS_SDKUTILS_ENDPOINTS_RULESET_H */

--- a/include/aws/sdkutils/partitions.h
+++ b/include/aws/sdkutils/partitions.h
@@ -9,6 +9,8 @@
 #include <aws/common/byte_buf.h>
 #include <aws/sdkutils/sdkutils.h>
 
+AWS_PUSH_SANE_WARNING_LEVEL
+
 struct aws_partitions_config;
 
 AWS_EXTERN_C_BEGIN
@@ -34,5 +36,6 @@ AWS_SDKUTILS_API struct aws_partitions_config *aws_partitions_config_acquire(str
 AWS_SDKUTILS_API struct aws_partitions_config *aws_partitions_config_release(struct aws_partitions_config *partitions);
 
 AWS_EXTERN_C_END
+AWS_POP_SANE_WARNING_LEVEL
 
 #endif /* AWS_SDKUTILS_PARTITIONS_H */

--- a/include/aws/sdkutils/resource_name.h
+++ b/include/aws/sdkutils/resource_name.h
@@ -10,6 +10,8 @@
 
 #include <aws/common/byte_buf.h>
 
+AWS_PUSH_SANE_WARNING_LEVEL
+
 struct aws_resource_name {
     struct aws_byte_cursor partition;
     struct aws_byte_cursor service;
@@ -40,5 +42,6 @@ AWS_SDKUTILS_API
 int aws_byte_buf_append_resource_name(struct aws_byte_buf *buf, const struct aws_resource_name *arn);
 
 AWS_EXTERN_C_END
+AWS_POP_SANE_WARNING_LEVEL
 
 #endif /* AWS_SDKUTILS_RESOURCE_NAME_H */

--- a/include/aws/sdkutils/sdkutils.h
+++ b/include/aws/sdkutils/sdkutils.h
@@ -10,6 +10,8 @@
 
 #include <aws/sdkutils/exports.h>
 
+AWS_PUSH_SANE_WARNING_LEVEL
+
 struct aws_allocator;
 
 #define AWS_C_SDKUTILS_PACKAGE_ID 15
@@ -47,5 +49,6 @@ AWS_SDKUTILS_API void aws_sdkutils_library_init(struct aws_allocator *allocator)
 AWS_SDKUTILS_API void aws_sdkutils_library_clean_up(void);
 
 AWS_EXTERN_C_END
+AWS_POP_SANE_WARNING_LEVEL
 
 #endif /* AWS_SDKUTILS_SDKUTILS_H */


### PR DESCRIPTION
*Description of changes:*
- Adds `AWS_PUSH_SANE_WARNING_LEVEL` and `AWS_POP_SANE_WARNING_LEVEL` to the public headers. The public header should contain at least one include; otherwise, we will receive a macro not found error. Therefore, I decided to skip adding these macros if there are no includes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.