### PR TITLE
update the behavior for profile override

### DIFF
--- a/source/aws_profile.c
+++ b/source/aws_profile.c
@@ -1542,16 +1542,18 @@ AWS_STATIC_STRING_FROM_LITERAL(s_default_profile_env_variable_name, "AWS_PROFILE
 
 struct aws_string *aws_get_profile_name(struct aws_allocator *allocator, const struct aws_byte_cursor *override_name) {
     /**
-     * The default profile must be used if the user does NOT specify a profile.
-     * the default profile can be overridden using the AWS_PROFILE environment variable.
-     */
+     * Profile name is resolved in the following order.
+     * 1. If the override_path variable is provided.
+     * 2. Check `AWS_PROFILE` environment variable and use the value if it is not empty.
+     * 3. Use "default". */
     struct aws_string *profile_name = NULL;
     if (override_name != NULL && override_name->ptr != NULL) {
         profile_name = aws_string_new_from_array(allocator, override_name->ptr, override_name->len);
     } else {
-        /* Use the default profile. Override the default profile with AWS_PROFILE environment variable if exist */
-        if (aws_get_environment_value(allocator, s_default_profile_env_variable_name, &profile_name) ||
-            profile_name == NULL) {
+        /* Try to fetch profile from AWS_PROFILE environment variable */
+        aws_get_environment_value(allocator, s_default_profile_env_variable_name, &profile_name);
+        /* Use default profile if it doesn't exist. */
+        if (profile_name == NULL) {
             profile_name = aws_string_new_from_string(allocator, s_default_profile_name);
         }
     }

--- a/source/aws_profile.c
+++ b/source/aws_profile.c
@@ -1541,14 +1541,17 @@ struct aws_string *aws_get_config_file_path(
 AWS_STATIC_STRING_FROM_LITERAL(s_default_profile_env_variable_name, "AWS_PROFILE");
 
 struct aws_string *aws_get_profile_name(struct aws_allocator *allocator, const struct aws_byte_cursor *override_name) {
-
+    /**
+     * The default profile must be used if the user does NOT specify a profile.
+     * the default profile can be overridden using the AWS_PROFILE environment variable.
+     */
     struct aws_string *profile_name = NULL;
-
-    if (aws_get_environment_value(allocator, s_default_profile_env_variable_name, &profile_name) ||
-        profile_name == NULL) {
-        if (override_name != NULL && override_name->ptr != NULL) {
-            profile_name = aws_string_new_from_array(allocator, override_name->ptr, override_name->len);
-        } else {
+    if (override_name != NULL && override_name->ptr != NULL) {
+        profile_name = aws_string_new_from_array(allocator, override_name->ptr, override_name->len);
+    } else {
+        /* Use the default profile. Override the default profile with AWS_PROFILE environment variable if exist */
+        if (aws_get_environment_value(allocator, s_default_profile_env_variable_name, &profile_name) ||
+            profile_name == NULL) {
             profile_name = aws_string_new_from_string(allocator, s_default_profile_name);
         }
     }

--- a/tests/aws_profile_tests.c
+++ b/tests/aws_profile_tests.c
@@ -1447,9 +1447,8 @@ AWS_STATIC_STRING_FROM_LITERAL(s_profile_override, "NotTheDefault");
 
 static int s_profile_override_test(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
-
-    /* Make sure the environment doesn't affect this test */
-    aws_unset_environment_value(s_profile_env_var);
+    /* The envrionment value should only override the default when user not set one */
+    aws_set_environment_value(s_profile_env_var, s_profile_override);
 
     struct aws_byte_cursor override_cursor = aws_byte_cursor_from_string(s_profile_override);
     struct aws_string *profile_name = aws_get_profile_name(allocator, &override_cursor);


### PR DESCRIPTION
*Issue #, if available:*

- We say we do what aws-cli does, [here](https://github.com/awslabs/aws-c-sdkutils/blob/main/include/aws/sdkutils/aws_profile.h#L24-L27)
- But, according to CLI doc [here](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html):
>   Specifies the name of the AWS CLI profile with the credentials and options to use. This can be the name of a profile stored in a credentials or config file, or the value default to use the default profile.
    If defined, this environment variable overrides the behavior of using the profile named [default] in the configuration file. You can override this environment variable by using the --profile command line parameter.

*Description of changes:*

- Change the behavior to make sure the provided `profile` override the environment variable. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
