### PR TITLE
aws_profile: reduce logging verbosity of the ~/.aws/profile parser

### DIFF
--- a/source/aws_profile.c
+++ b/source/aws_profile.c
@@ -346,7 +346,7 @@ static int s_profile_property_add_sub_property(
     int was_present = 0;
     aws_hash_table_remove(&property->sub_properties, key_string, NULL, &was_present);
     if (was_present) {
-        AWS_LOGF_WARN(
+        AWS_LOGF_DEBUG(
             AWS_LS_SDKUTILS_PROFILE,
             "subproperty \"%s\" of property \"%s\" had value overridden with new value",
             key_string->bytes,
@@ -385,7 +385,7 @@ static int s_profile_property_merge(struct aws_profile_property *dest, const str
         }
 
         if (dest->value) {
-            AWS_LOGF_WARN(
+            AWS_LOGF_DEBUG(
                 AWS_LS_SDKUTILS_PROFILE,
                 "property \"%s\" has value \"%s\" replaced during merge",
                 dest->name->bytes,
@@ -420,7 +420,7 @@ static int s_profile_property_merge(struct aws_profile_property *dest, const str
         int was_present = 0;
         aws_hash_table_remove(&dest->sub_properties, dest_key, NULL, &was_present);
         if (was_present) {
-            AWS_LOGF_WARN(
+            AWS_LOGF_DEBUG(
                 AWS_LS_SDKUTILS_PROFILE,
                 "subproperty \"%s\" of property \"%s\" had value overridden during property merge",
                 dest_key->bytes,
@@ -665,7 +665,7 @@ static int s_profile_collection_add_profile(
              * existing one supercedes: ignore this (and its properties) completely by failing the add
              * which sets the current profile to NULL
              */
-            AWS_LOGF_WARN(
+            AWS_LOGF_DEBUG(
                 AWS_LS_SDKUTILS_PROFILE,
                 "Existing prefixed default config profile supercedes unprefixed default profile");
             s_log_parse_context(AWS_LL_WARN, context);
@@ -678,7 +678,7 @@ static int s_profile_collection_add_profile(
              * stomp over existing: remove it, then proceed with add
              * element destroy function will clean up the profile and key
              */
-            AWS_LOGF_WARN(
+            AWS_LOGF_DEBUG(
                 AWS_LS_SDKUTILS_PROFILE, "Prefixed default config profile replacing unprefixed default profile");
             s_log_parse_context(AWS_LL_WARN, context);
 
@@ -1039,7 +1039,7 @@ static bool s_parse_property_continuation(
      * A continuation without a current property is bad
      */
     if (context->current_profile == NULL || context->current_property == NULL) {
-        AWS_LOGF_WARN(AWS_LS_SDKUTILS_PROFILE, "Property continuation seen outside of a current property");
+        AWS_LOGF_DEBUG(AWS_LS_SDKUTILS_PROFILE, "Property continuation seen outside of a current property");
         s_log_parse_context(AWS_LL_WARN, context);
 
         context->parse_error = AWS_ERROR_SDKUTILS_PARSE_FATAL;
@@ -1047,7 +1047,7 @@ static bool s_parse_property_continuation(
     }
 
     if (s_profile_property_add_continuation(context->current_property, &continuation_cursor)) {
-        AWS_LOGF_WARN(AWS_LS_SDKUTILS_PROFILE, "Property continuation could not be applied to the current property");
+        AWS_LOGF_DEBUG(AWS_LS_SDKUTILS_PROFILE, "Property continuation could not be applied to the current property");
         s_log_parse_context(AWS_LL_WARN, context);
 
         context->parse_error = AWS_ERROR_SDKUTILS_PARSE_RECOVERABLE;
@@ -1155,7 +1155,7 @@ static bool s_parse_property(const struct aws_byte_cursor *line_cursor, struct p
         context->current_property =
             s_profile_add_property(context->current_profile, &trimmed_key_cursor, &property_cursor);
         if (context->current_property == NULL) {
-            AWS_LOGF_ERROR(
+            AWS_LOGF_DEBUG(
                 AWS_LS_SDKUTILS_PROFILE,
                 "Failed to add property \"" PRInSTR "\" to current profile \"%s\"",
                 AWS_BYTE_CURSOR_PRI(trimmed_key_cursor),
@@ -1214,7 +1214,7 @@ static void s_parse_and_apply_line_to_profile_collection(
         return;
     }
 
-    AWS_LOGF_WARN(AWS_LS_SDKUTILS_PROFILE, "Unidentifiable line type encountered while parsing profile file");
+    AWS_LOGF_DEBUG(AWS_LS_SDKUTILS_PROFILE, "Unidentifiable line type encountered while parsing profile file");
     s_log_parse_context(AWS_LL_WARN, context);
 
     context->parse_error = AWS_ERROR_SDKUTILS_PARSE_FATAL;
@@ -1316,7 +1316,7 @@ struct aws_profile_collection *aws_profile_collection_new_from_file(
     AWS_LOGF_DEBUG(AWS_LS_SDKUTILS_PROFILE, "Creating profile collection from file at \"%s\"", file_path->bytes);
 
     if (aws_byte_buf_init_from_file(&file_contents, allocator, aws_string_c_str(file_path)) != 0) {
-        AWS_LOGF_WARN(AWS_LS_SDKUTILS_PROFILE, "Failed to read file at \"%s\"", file_path->bytes);
+        AWS_LOGF_DEBUG(AWS_LS_SDKUTILS_PROFILE, "Failed to read file at \"%s\"", file_path->bytes);
         return NULL;
     }
 

--- a/source/aws_profile.c
+++ b/source/aws_profile.c
@@ -1039,7 +1039,7 @@ static bool s_parse_property_continuation(
      * A continuation without a current property is bad
      */
     if (context->current_profile == NULL || context->current_property == NULL) {
-        AWS_LOGF_DEBUG(AWS_LS_SDKUTILS_PROFILE, "Property continuation seen outside of a current property");
+        AWS_LOGF_ERROR(AWS_LS_SDKUTILS_PROFILE, "Property continuation seen outside of a current property");
         s_log_parse_context(AWS_LL_WARN, context);
 
         context->parse_error = AWS_ERROR_SDKUTILS_PARSE_FATAL;

--- a/source/aws_profile.c
+++ b/source/aws_profile.c
@@ -1155,7 +1155,7 @@ static bool s_parse_property(const struct aws_byte_cursor *line_cursor, struct p
         context->current_property =
             s_profile_add_property(context->current_profile, &trimmed_key_cursor, &property_cursor);
         if (context->current_property == NULL) {
-            AWS_LOGF_DEBUG(
+            AWS_LOGF_ERROR(
                 AWS_LS_SDKUTILS_PROFILE,
                 "Failed to add property \"" PRInSTR "\" to current profile \"%s\"",
                 AWS_BYTE_CURSOR_PRI(trimmed_key_cursor),
@@ -1214,7 +1214,7 @@ static void s_parse_and_apply_line_to_profile_collection(
         return;
     }
 
-    AWS_LOGF_DEBUG(AWS_LS_SDKUTILS_PROFILE, "Unidentifiable line type encountered while parsing profile file");
+    AWS_LOGF_ERROR(AWS_LS_SDKUTILS_PROFILE, "Unidentifiable line type encountered while parsing profile file");
     s_log_parse_context(AWS_LL_WARN, context);
 
     context->parse_error = AWS_ERROR_SDKUTILS_PARSE_FATAL;


### PR DESCRIPTION
The profile parser is used frequently and in many places. Its logging level is very verbose. Even when it is clear that `~/.aws/profile` does not exist (e.g. on kubernetes nodes using STS), it repeatedly logs entries like these:
```console
[ERROR] 2022-03-14 22:05:06.078 file-utils [139977917552384] static: Failed to open file /root/.aws/config with errno 2
[ERROR] 2022-03-14 22:05:06.088 file-utils [139977917552384] static: Failed to open file /root/.aws/credentials with errno 2
```
We have found that the verbose logs confuse users in production, causing unnecessary tickets to be raised.

Reduce the verbosity of frequently used logging messages to `DEBUG`; to allow seeing the messages when troubleshooting.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
