### PR TITLE
Remove arg with cxx keyword from header.

### DIFF
--- a/include/aws/sdkutils/private/endpoints_util.h
+++ b/include/aws/sdkutils/private/endpoints_util.h
@@ -74,7 +74,7 @@ AWS_SDKUTILS_API void aws_array_list_deep_clean_up(
 
 /* Function that resolves template. */
 typedef int(aws_endpoints_template_resolve_fn)(
-    struct aws_byte_cursor template,
+    struct aws_byte_cursor /* template */,
     void *user_data,
     struct aws_owning_cursor *out_resolved);
 /*


### PR DESCRIPTION
*Issue #, if available:*
When building a Swift module with cxx-interop enabled, this module gets imported by clang as a C++ header.  Since `template` is a C++ keyword, it causes problems.

*Description of changes:*
Just comment out the argument name in the header.  C only requires the type.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
