### PR TITLE
Add cxx support

### DIFF
--- a/include/aws/sdkutils/private/endpoints_util.h
+++ b/include/aws/sdkutils/private/endpoints_util.h
@@ -74,7 +74,7 @@ AWS_SDKUTILS_API void aws_array_list_deep_clean_up(
 
 /* Function that resolves template. */
 typedef int(aws_endpoints_template_resolve_fn)(
-    struct aws_byte_cursor template,
+    struct aws_byte_cursor template_cursor,
     void *user_data,
     struct aws_owning_cursor *out_resolved);
 /*


### PR DESCRIPTION
*Issue #, if available:* 
https://github.com/awslabs/aws-crt-swift/pull/294

*Description of changes:* 
* Replaced the variable name `template` with `template_cursor` to resolve reserved keyword issue, which adds CXX interoperability support for `aws-crt-swift`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
