### PR TITLE
make exports consistent

### DIFF
--- a/include/aws/sdkutils/exports.h
+++ b/include/aws/sdkutils/exports.h
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-#if defined(USE_WINDOWS_DLL_SEMANTICS) || defined(WIN32)
+#if defined(AWS_CRT_USE_WINDOWS_DLL_SEMANTICS) || defined(_WIN32)
 #    ifdef AWS_SDKUTILS_USE_IMPORT_EXPORT
 #        ifdef AWS_SDKUTILS_EXPORTS
 #            define AWS_SDKUTILS_API __declspec(dllexport)
@@ -18,13 +18,12 @@
 #    endif /*USE_IMPORT_EXPORT */
 
 #else
-#    if ((__GNUC__ >= 4) || defined(__clang__)) && defined(AWS_SDKUTILS_USE_IMPORT_EXPORT) &&                          \
-        defined(AWS_SDKUTILS_EXPORTS)
+#    if defined(AWS_SDKUTILS_USE_IMPORT_EXPORT) && defined(AWS_SDKUTILS_EXPORTS)
 #        define AWS_SDKUTILS_API __attribute__((visibility("default")))
 #    else
 #        define AWS_SDKUTILS_API
-#    endif /* __GNUC__ >= 4 || defined(__clang__) */
+#    endif
 
-#endif /* defined(USE_WINDOWS_DLL_SEMANTICS) || defined(WIN32) */
+#endif /* defined(AWS_CRT_USE_WINDOWS_DLL_SEMANTICS) || defined(_WIN32) */
 
 #endif /* AWS_SDKUTILS_EXPORTS_H */


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
make AWS_CRT_USE_WINDOWS_DLL_SEMANTICS the variable for forcing win semantics
remove gcc < 4

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
