### PR TITLE
Allow special characters in profile names.

### DIFF
--- a/source/aws_profile.c
+++ b/source/aws_profile.c
@@ -59,7 +59,8 @@ static bool s_is_identifier(uint8_t value) {
 
     if ((value_as_char >= 'A' && value_as_char <= 'Z') || (value_as_char >= 'a' && value_as_char <= 'z') ||
         (value_as_char >= '0' && value_as_char <= '9') || value_as_char == '\\' || value_as_char == '_' ||
-        value_as_char == '-') {
+        value_as_char == '-' || value_as_char == '/' || value_as_char == '.' || value_as_char == '%' ||
+        value_as_char == '@' || value_as_char == ':' || value_as_char == '+') {
         return true;
     }
 

--- a/tests/aws_profile_tests.c
+++ b/tests/aws_profile_tests.c
@@ -1070,7 +1070,7 @@ AWS_TEST_CASE(aws_profile_invalid_property_names_ignored_test, s_aws_profile_inv
  */
 AWS_STATIC_STRING_FROM_LITERAL(
     s_all_valid_profile_characters_profile,
-    "[profile ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_]");
+    "[profile ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_/.%@:+]");
 
 static int s_aws_profile_all_valid_profile_characters_test(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
@@ -1083,11 +1083,11 @@ static int s_aws_profile_all_valid_profile_characters_test(struct aws_allocator 
     EXPECT_SECTION(
         profile_collection,
         AWS_PROFILE_SECTION_TYPE_PROFILE,
-        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_");
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_/.%@:+");
     EXPECT_PROPERTY_COUNT(
         profile_collection,
         AWS_PROFILE_SECTION_TYPE_PROFILE,
-        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_",
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_/.%@:+",
         0);
 
     aws_profile_collection_destroy(profile_collection);
@@ -1102,7 +1102,7 @@ AWS_TEST_CASE(aws_profile_all_valid_profile_characters_test, s_aws_profile_all_v
  */
 AWS_STATIC_STRING_FROM_LITERAL(
     s_all_valid_property_characters_profile,
-    "[profile foo]\nABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_ = value");
+    "[profile foo]\nABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_/.%@:+ = value");
 
 static int s_aws_profile_all_valid_property_characters_test(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
@@ -1118,7 +1118,7 @@ static int s_aws_profile_all_valid_property_characters_test(struct aws_allocator
         profile_collection,
         AWS_PROFILE_SECTION_TYPE_PROFILE,
         "foo",
-        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_",
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_/.%@:+",
         "value");
 
     aws_profile_collection_destroy(profile_collection);


### PR DESCRIPTION
*Description of changes:*
The AWS CLI and SDKs allows a wide set of characters in profile names. Trying to use the aws-crt credential provider with a profile named for example "foo.bar@123456" fails with a warning log like:

```
Profile declaration contains invalid characters: ".bar@123456"
```

Looking around at the SDKs and CLI, I can see two options:

* Allow "anything". Botocore falls into this category, as far as I can tell.
* Allow `A-Za-z0-9_-/.%@:+`. This is the case for at least the Typescript and Java SDKs (the Java implementation is in an open PR), with the Java one referencing "the AWS SDK shared-configuration SEP", which I'm assuming is some AWS internal standard.

This changes the profile name parsing to align with the SDKs. The one difference is that aws-crt historically allowed `\`, which the SDKs don't. I'm keeping it to remain backwards compatible.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
