### PR TITLE
[fix] deepcopy user provided name

### DIFF
--- a/include/aws/sdkutils/private/endpoints_types_impl.h
+++ b/include/aws/sdkutils/private/endpoints_types_impl.h
@@ -349,7 +349,8 @@ void aws_endpoints_expr_clean_up(struct aws_endpoints_expr *expr);
 
 struct aws_endpoints_scope_value *aws_endpoints_scope_value_new(
     struct aws_allocator *allocator,
-    struct aws_byte_cursor name_cur);
+    struct aws_byte_cursor name_cur,
+    bool should_own);
 void aws_endpoints_scope_value_destroy(struct aws_endpoints_scope_value *scope_value);
 
 int aws_endpoints_deep_copy_parameter_value(

--- a/source/endpoints_rule_engine.c
+++ b/source/endpoints_rule_engine.c
@@ -78,7 +78,8 @@ static int s_deep_copy_context_to_scope(
 
         struct aws_endpoints_scope_value *context_value = (struct aws_endpoints_scope_value *)iter.element.value;
 
-        new_value = aws_endpoints_scope_value_new(allocator, context_value->name.cur);
+        /* Own the name: context_value may be freed after resolve returns */
+        new_value = aws_endpoints_scope_value_new(allocator, context_value->name.cur, true);
         if (aws_endpoints_deep_copy_parameter_value(allocator, &context_value->value, &new_value->value)) {
             AWS_LOGF_ERROR(AWS_LS_SDKUTILS_ENDPOINTS_RESOLVE, "Failed to deep copy value.");
             goto on_error;
@@ -157,7 +158,8 @@ static int s_init_top_level_scope(
                 goto on_error;
             }
 
-            struct aws_endpoints_scope_value *val = aws_endpoints_scope_value_new(allocator, key);
+            /* Non-owning: key points into ruleset which outlives the scope */
+            struct aws_endpoints_scope_value *val = aws_endpoints_scope_value_new(allocator, key, false);
             AWS_ASSERT(val);
 
             switch (value->type) {
@@ -221,7 +223,8 @@ static int s_resolve_one_condition(
     if (*out_is_truthy && condition->assign.len > 0) {
         /* If condition assigns a value, push it to scope and let scope
         handle value memory. */
-        scope_value = aws_endpoints_scope_value_new(allocator, condition->assign);
+        /* Non-owning: condition->assign points into ruleset which outlives the scope */
+        scope_value = aws_endpoints_scope_value_new(allocator, condition->assign, false);
         scope_value->value = val;
 
         if (aws_array_list_push_back(&state->added_keys, &scope_value->name.cur)) {
@@ -478,7 +481,8 @@ int aws_endpoints_request_context_add_string(
     struct aws_byte_cursor value) {
     AWS_PRECONDITION(allocator);
 
-    struct aws_endpoints_scope_value *val = aws_endpoints_scope_value_new(allocator, name);
+    /* Own the name: caller-provided cursor may not outlive this call */
+    struct aws_endpoints_scope_value *val = aws_endpoints_scope_value_new(allocator, name, true);
     val->value.type = AWS_ENDPOINTS_VALUE_STRING;
     val->value.v.owning_cursor_string = aws_endpoints_owning_cursor_from_cursor(allocator, value);
 
@@ -497,7 +501,8 @@ int aws_endpoints_request_context_add_boolean(
     bool value) {
     AWS_PRECONDITION(allocator);
 
-    struct aws_endpoints_scope_value *val = aws_endpoints_scope_value_new(allocator, name);
+    /* Own the name: caller-provided cursor may not outlive this call */
+    struct aws_endpoints_scope_value *val = aws_endpoints_scope_value_new(allocator, name, true);
     val->value.type = AWS_ENDPOINTS_VALUE_BOOLEAN;
     val->value.v.boolean = value;
 
@@ -516,7 +521,8 @@ int aws_endpoints_request_context_add_string_array(
     const struct aws_byte_cursor *values,
     size_t len) {
 
-    struct aws_endpoints_scope_value *val = aws_endpoints_scope_value_new(allocator, name);
+    /* Own the name: caller-provided cursor may not outlive this call */
+    struct aws_endpoints_scope_value *val = aws_endpoints_scope_value_new(allocator, name, true);
     val->value.type = AWS_ENDPOINTS_VALUE_ARRAY;
     aws_array_list_init_dynamic(&val->value.v.array, allocator, len, sizeof(struct aws_endpoints_value));
 

--- a/source/endpoints_types_impl.c
+++ b/source/endpoints_types_impl.c
@@ -167,12 +167,14 @@ void aws_endpoints_expr_clean_up(struct aws_endpoints_expr *expr) {
 
 struct aws_endpoints_scope_value *aws_endpoints_scope_value_new(
     struct aws_allocator *allocator,
-    struct aws_byte_cursor name_cur) {
+    struct aws_byte_cursor name_cur,
+    bool should_own) {
     AWS_PRECONDITION(allocator);
     struct aws_endpoints_scope_value *value = aws_mem_calloc(allocator, 1, sizeof(struct aws_endpoints_scope_value));
 
     value->allocator = allocator;
-    value->name = aws_endpoints_non_owning_cursor_create(name_cur);
+    value->name = should_own ? aws_endpoints_owning_cursor_from_cursor(allocator, name_cur)
+                             : aws_endpoints_non_owning_cursor_create(name_cur);
 
     return value;
 }

--- a/tests/endpoints_rule_engine_tests.c
+++ b/tests/endpoints_rule_engine_tests.c
@@ -42,6 +42,15 @@ static int read_file_contents(
     return AWS_OP_SUCCESS;
 }
 
+static int s_add_context(struct aws_endpoints_request_context *context, struct aws_allocator *alloc) {
+    struct aws_string *region = aws_string_new_from_c_str(alloc, "Region");
+
+    ASSERT_SUCCESS(aws_endpoints_request_context_add_string(
+        alloc, context, aws_byte_cursor_from_string(region), aws_byte_cursor_from_c_str("us-west-2")));
+    aws_string_destroy(region);
+    return AWS_OP_SUCCESS;
+}
+
 AWS_TEST_CASE(parse_ruleset_from_string, s_test_parse_ruleset_from_string)
 static int s_test_parse_ruleset_from_string(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
@@ -81,8 +90,7 @@ static int s_test_parse_ruleset_from_string(struct aws_allocator *allocator, voi
     struct aws_endpoints_rule_engine *engine = aws_endpoints_rule_engine_new(allocator, ruleset, partitions);
 
     struct aws_endpoints_request_context *context = aws_endpoints_request_context_new(allocator);
-    ASSERT_SUCCESS(aws_endpoints_request_context_add_string(
-        allocator, context, aws_byte_cursor_from_c_str("Region"), aws_byte_cursor_from_c_str("us-west-2")));
+    ASSERT_SUCCESS(s_add_context(context, allocator));
 
     struct aws_endpoints_resolved_endpoint *resolved_endpoint = NULL;
     clock_t begin_resolve = clock();


### PR DESCRIPTION
**Description:**

`aws_endpoints_scope_value_new` stored the `name` cursor as non-owning, pointing directly into the caller's buffer. For the public `aws_endpoints_request_context_add_*` APIs, callers may free or invalidate that buffer immediately after the call returns (e.g., Swift's `withByteCursor` pattern provides a temporary pointer). This caused the hash table key to become a dangling pointer, leading to lookup failures during endpoint resolution.

The fix adds a `bool should_own` parameter to `aws_endpoints_scope_value_new`:
- `true` — allocates a copy of the name string. Used for caller-provided data (the 3 public `add_*` APIs) and for `s_deep_copy_context_to_scope` where the source context may not outlive the resolution scope.
- `false` — non-owning reference. Used when the name points into the ruleset, which is guaranteed to outlive the scope (parameter defaults, condition assigns).
