### PR TITLE
fix bdd header encoding

### DIFF
--- a/compiler/bdd-bytecoder.py
+++ b/compiler/bdd-bytecoder.py
@@ -245,7 +245,7 @@ def encode_results(buf, data, strings):
             props = ep.get("properties", {})
             props_json = json.dumps(props, separators=(",", ":")) if props else ""
             write_string_ref(buf, *strings.add(props_json))
-            headers = data.get("headers", {})
+            headers = ep.get("headers", {})
             buf += struct.pack("<H", len(headers))
             for name, vs in headers.items():
                 write_string_ref(buf, *strings.add(name))


### PR DESCRIPTION
*Description of changes:*

Fixes header encoding in BDD byte encoding. [currently it expects](https://github.com/awslabs/aws-c-sdkutils/blob/main/compiler/bdd-bytecoder.py#L235-L260):

```json
{
    "headers": {
                    ...,
    },
    "results": [
        {
            "endpoint": {
                ...,
                "properties": {
                    ...
                },
            },
            "type": "endpoint"
        }
    ]
}
```

in [s3 control that is actually](https://github.com/aws/aws-sdk-cpp/blob/main/tools/code-generation/smithy/api-descriptions/s3-control.json#L1546-L1552):
```json
{
    "results": [
        {
            "endpoint": {
                ...,
                "properties": {
                    ...
                },
                "headers": {
                    ...,
                }
            },
            "type": "endpoint"
        }
    ]
}
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
