### PR TITLE
Relax handling of unmodeled context params in bdd

### DIFF
--- a/source/endpoints_bdd_engine.c
+++ b/source/endpoints_bdd_engine.c
@@ -21,10 +21,10 @@ static int s_copy_context_to_state(
 
         if (element == NULL) {
             /**
-             * Technically all context params need to be defined in the model, i.e. 
-             * we should have already mapped a register for them. But some SDKs populate 
-             * context with undefined context params (giving you a side look cpp). 
-             * In general, we can just ignore those params, since they will not be derefed 
+             * Technically all context params need to be defined in the model, i.e.
+             * we should have already mapped a register for them. But some SDKs populate
+             * context with undefined context params (giving you a side look cpp).
+             * In general, we can just ignore those params, since they will not be derefed
              * by the rules anyways.
              */
             continue;

--- a/source/endpoints_bdd_engine.c
+++ b/source/endpoints_bdd_engine.c
@@ -20,11 +20,14 @@ static int s_copy_context_to_state(
         aws_hash_table_find(&state->engine->register_map, &context_value->name.cur, &element);
 
         if (element == NULL) {
-            AWS_LOGF_ERROR(
-                AWS_LS_SDKUTILS_ENDPOINTS_RESOLVE,
-                "Received a context variable not present in parameters: " PRInSTR,
-                AWS_BYTE_CURSOR_PRI(context_value->name.cur));
-            return aws_raise_error(AWS_ERROR_SDKUTILS_ENDPOINTS_RESOLVE_INIT_FAILED);
+            /**
+             * Technically all context params need to be defined in the model, i.e. 
+             * we should have already mapped a register for them. But some SDKs populate 
+             * context with undefined context params (giving you a side look cpp). 
+             * In general, we can just ignore those params, since they will not be derefed 
+             * by the rules anyways.
+             */
+            continue;
         }
 
         size_t idx = (size_t)element->value;

--- a/tests/endpoint_bdd_tests.c
+++ b/tests/endpoint_bdd_tests.c
@@ -51,7 +51,9 @@ static int s_test_bdd_virtual(struct aws_allocator *allocator, void *ctx) {
         allocator, context, aws_byte_cursor_from_c_str("Region"), aws_byte_cursor_from_c_str("us-west-2")));
     /* add undefined param to make sure it still passes. */
     ASSERT_SUCCESS(aws_endpoints_request_context_add_string(
-        allocator, context, aws_byte_cursor_from_c_str("AnotherRegion"), 
+        allocator,
+        context,
+        aws_byte_cursor_from_c_str("AnotherRegion"),
         aws_byte_cursor_from_c_str("old-snake-is-back")));
     ASSERT_SUCCESS(aws_endpoints_request_context_add_string(
         allocator, context, aws_byte_cursor_from_c_str("Bucket"), aws_byte_cursor_from_c_str("bucket-name")));

--- a/tests/endpoint_bdd_tests.c
+++ b/tests/endpoint_bdd_tests.c
@@ -51,7 +51,8 @@ static int s_test_bdd_virtual(struct aws_allocator *allocator, void *ctx) {
         allocator, context, aws_byte_cursor_from_c_str("Region"), aws_byte_cursor_from_c_str("us-west-2")));
     /* add undefined param to make sure it still passes. */
     ASSERT_SUCCESS(aws_endpoints_request_context_add_string(
-        allocator, context, aws_byte_cursor_from_c_str("AnotherRegion"), aws_byte_cursor_from_c_str("old-snake-is-back")));
+        allocator, context, aws_byte_cursor_from_c_str("AnotherRegion"), 
+        aws_byte_cursor_from_c_str("old-snake-is-back")));
     ASSERT_SUCCESS(aws_endpoints_request_context_add_string(
         allocator, context, aws_byte_cursor_from_c_str("Bucket"), aws_byte_cursor_from_c_str("bucket-name")));
 

--- a/tests/endpoint_bdd_tests.c
+++ b/tests/endpoint_bdd_tests.c
@@ -51,7 +51,7 @@ static int s_test_bdd_virtual(struct aws_allocator *allocator, void *ctx) {
         allocator, context, aws_byte_cursor_from_c_str("Region"), aws_byte_cursor_from_c_str("us-west-2")));
     /* add undefined param to make sure it still passes. */
     ASSERT_SUCCESS(aws_endpoints_request_context_add_string(
-        allocator, context, aws_byte_cursor_from_c_str("AnotherRegion"), aws_byte_cursor_from_c_str("us-west-2")));
+        allocator, context, aws_byte_cursor_from_c_str("AnotherRegion"), aws_byte_cursor_from_c_str("old-snake-is-back")));
     ASSERT_SUCCESS(aws_endpoints_request_context_add_string(
         allocator, context, aws_byte_cursor_from_c_str("Bucket"), aws_byte_cursor_from_c_str("bucket-name")));
 

--- a/tests/endpoint_bdd_tests.c
+++ b/tests/endpoint_bdd_tests.c
@@ -49,6 +49,9 @@ static int s_test_bdd_virtual(struct aws_allocator *allocator, void *ctx) {
     struct aws_endpoints_request_context *context = aws_endpoints_request_context_new(allocator);
     ASSERT_SUCCESS(aws_endpoints_request_context_add_string(
         allocator, context, aws_byte_cursor_from_c_str("Region"), aws_byte_cursor_from_c_str("us-west-2")));
+    /* add undefined param to make sure it still passes. */
+    ASSERT_SUCCESS(aws_endpoints_request_context_add_string(
+        allocator, context, aws_byte_cursor_from_c_str("AnotherRegion"), aws_byte_cursor_from_c_str("us-west-2")));
     ASSERT_SUCCESS(aws_endpoints_request_context_add_string(
         allocator, context, aws_byte_cursor_from_c_str("Bucket"), aws_byte_cursor_from_c_str("bucket-name")));
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Unmodeled context params currently error out in bdd. Technically sdks should not be sending them, but also its really easy to just ignore those in bdd.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
